### PR TITLE
dockerise

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+list.txt

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,35 @@
+name: Build and Push
+
+permissions:
+  contents: read
+  packages: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /source
+
+COPY *.sln *.csproj ./
+RUN dotnet restore
+
+COPY . .
+RUN dotnet publish -c release -o /app --no-restore --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false
+
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-noble-chiseled
+WORKDIR /app
+COPY --from=build /app ./
+
+ENV URLS="http://+:5000"
+
+EXPOSE 5000
+
+ENTRYPOINT ["/app/webring"]

--- a/Program.cs
+++ b/Program.cs
@@ -5,7 +5,7 @@ List<Website> websites = new();
 var random = new Random();
 
 var env = Environment.GetEnvironmentVariable("WEBRING_LIST");
-string[] lines = env == null ? File.ReadAllLines("list.txt") : env.Split("\n");
+string[] lines = env == null ? File.ReadAllLines("list.txt") : env.Trim().Split("\n");
 foreach (string line in lines)
 {
     string url = null;

--- a/Program.cs
+++ b/Program.cs
@@ -4,7 +4,8 @@ using Microsoft.AspNetCore.HttpOverrides;
 List<Website> websites = new();
 var random = new Random();
 
-string[] lines = File.ReadAllLines("list.txt");
+var env = Environment.GetEnvironmentVariable("WEBRING_LIST");
+string[] lines = env == null ? File.ReadAllLines("list.txt") : env.Split("\n");
 foreach (string line in lines)
 {
     string url = null;
@@ -40,7 +41,6 @@ app.UseForwardedHeaders(new ForwardedHeadersOptions
     ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
 });
 
-app.UseHttpsRedirection();  // redirect 80 to 443
 app.UseCors(MyAllowSpecificOrigins);
 
 app.MapGet("/", () =>
@@ -106,7 +106,8 @@ app.MapGet("/rand", () =>
     return Results.Redirect(websites[random.Next(websites.Count)].domains.First());
 });
 
-app.MapGet("/members", () => {
+app.MapGet("/members", () =>
+{
     Console.WriteLine("/members: requested members with badges");
     return Results.Text(JsonConvert.SerializeObject(websites));
 });

--- a/webring.csproj
+++ b/webring.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- removed http to https redirect (don't do it inside the apps you are putting behind a balancer!)
- added support for `WEBRING_LIST` env var that takes precedence over `list.txt` if set
- dockerised

To spin up with the current list, do this:
```yaml
version: '3.7'
services:
  app:
    image: ghcr.io/hummusbird/webring:latest
    restart: always
    ports:
      - 22111:5000
    labels:
      com.centurylinklabs.watchtower.enable: 'true'
    environment:
      WEBRING_LIST: |-
        birb;https://miaow.ing/,https://miaowi.ng/,https://birb.cc/,https://hummusbird.co.uk/,https://webring.birb.cc/;https://birb.cc/images/88x31_miaowing.png
        bobthebob;https://joke.enterprises/;https://joke.enterprises/badge88_31.png
        lysdal;https://witchrose.com/;https://witchrose.com/88x31.gif
        alyxia;https://alyxia.dev/;https://alyxia.dev/static/img/88x31/self.png
        ayle;https://lostorstolen.neocities.org/;https://lostorstolen.neocities.org/eye-luh.gif
```